### PR TITLE
update default template for twig

### DIFF
--- a/templates/swiftmailer.html.twig
+++ b/templates/swiftmailer.html.twig
@@ -1,16 +1,13 @@
-<?php
-/**
- * @file
- * The default template file for e-mails.
- */
-?>
+<html>
+<head>
 <style type="text/css">
 table tr td {
   font-family: Arial;
   font-size: 12px;
 }
 </style>
-
+</head>
+<body>
 <div>
   <table width="800px" cellpadding="0" cellspacing="0">
     <tr>
@@ -22,3 +19,5 @@ table tr td {
     </tr>
   </table>
 </div>
+</body>
+</html>


### PR DESCRIPTION
The default template was probably copied over from a php template file; in D8 it currently outputs php and lacks html tags.
